### PR TITLE
Change recommended command to improve escaped character support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,15 @@ SharpAI is open source stack for machine learning engineering with private deplo
 ```
 sudo curl -sSL https://get.docker.com | sh
 ```
-2. Get source code
+2. Install Docker-compose
+```
+sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+```
+3. Get source code
 ```
 git clone https://github.com/SharpAI/DeepCamera
 ```
-3. Start container
+4. Start container
 ```
 cd DeepCamera/
 ./run-on-linux.sh start

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ sudo curl -sSL https://get.docker.com | sh
 2. Install Docker-compose
 ```
 sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
 ```
 3. Get source code
 ```

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Response:
 ### Get Token of created user
 REST API:
 ```
-curl -X POST http://localhost:3000/api/v1/login/ -d "username=testuser&password=123456"
+curl -X POST -H "Content-type: application/json" http://localhost:3000/api/v1/login/ -d '{"username": "test11", "email": "xxxx@xxx.xx", "password": "123456"}'
 ```
 Response:
 ```


### PR DESCRIPTION
Changed command syntax for logging in to match syntax for registering because the syntax used for registering properly escapes bash special characters, but the syntax used for logging in does not. This allows you to create a user with a bash special character such as ! or | in the password, but the login command will fail with an error. The login works with special characters however if the same syntax is used as registration. I am updating this to hopefully help others avoid the same issue I discovered.