### PR TITLE
fix(depth-estimation): use --ignore-requires-python for Python 3.11 c…

### DIFF
--- a/skills/transformation/depth-estimation/SKILL.md
+++ b/skills/transformation/depth-estimation/SKILL.md
@@ -97,5 +97,5 @@ class MyPrivacySkill(TransformSkillBase):
 
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
+pip install --ignore-requires-python -r requirements.txt
 ```

--- a/skills/transformation/depth-estimation/requirements.txt
+++ b/skills/transformation/depth-estimation/requirements.txt
@@ -1,6 +1,10 @@
 # Depth Estimation — Privacy Transform Skill
 # NOTE: torch and torchvision MUST be version-paired.
 # Loose ranges cause pip to flip between incompatible versions.
+#
+# INSTALL WITH: pip install --ignore-requires-python -r requirements.txt
+# The depth-anything-v2 PyPI wheel declares python_requires>=3.12 in its
+# metadata, but is pure Python (py3-none-any) and works on Python 3.11+.
 torch~=2.7.0
 torchvision~=0.22.0
 depth-anything-v2>=0.1.0


### PR DESCRIPTION
…ompat

The depth-anything-v2 PyPI wheel (0.1.0) declares python_requires>=3.12 but is pure Python (py3-none-any) and works on 3.11+. Updated SKILL.md setup instructions and added a comment in requirements.txt so the deployment agent uses the correct pip flags.