### PR TITLE
feat: benchmark Operations Center with live progress dashboard

### DIFF
--- a/skills/analysis/home-security-benchmark/scripts/generate-report.cjs
+++ b/skills/analysis/home-security-benchmark/scripts/generate-report.cjs
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
 /**
- * HTML Report Generator for Home Security AI Benchmark
+ * HomeSec-Bench Operations Center — Report Generator
  * 
- * Reads JSON result files from the benchmarks directory and generates
- * a self-contained HTML report with:
- * - Pass/fail scorecard per suite
- * - Latency charts (inline SVG)
- * - Token usage breakdown
- * - Historical comparison table
- * - System configuration
+ * Generates a self-contained HTML dashboard with three views:
+ *   ⚡ Performance — TTFT, decode tok/s, server metrics, trend charts
+ *   ✅ Quality    — Suite pass/fail, test details, comparison tables
+ *   🖼️ Vision     — VLM image grid with pass/fail overlays and model responses
+ * 
+ * Features:
+ *   - Run picker sidebar with model-grouped history + multi-select
+ *   - Side-by-side comparison tables across selected runs
+ *   - Export to Markdown for community sharing
+ *   - Embeds all data into a single offline-capable HTML file
  * 
  * Usage:
  *   node generate-report.cjs [results-dir]
@@ -21,260 +24,830 @@ const os = require('os');
 
 const RESULTS_DIR = process.argv[2] || path.join(os.homedir(), '.aegis-ai', 'benchmarks');
 
-function generateReport(resultsDir = RESULTS_DIR) {
+// ─── Fixture image directory (for Vision tab) ──────────────────────────────────
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures', 'frames');
+
+/**
+ * Generate the report HTML.
+ * @param {string} resultsDir - Directory containing benchmark results
+ * @param {object} opts - Options
+ * @param {boolean} opts.liveMode - If true, adds auto-refresh (5s) and a live progress banner
+ * @param {object} opts.liveStatus - Live status info: { suitesCompleted, totalSuites, currentSuite, startedAt }
+ */
+function generateReport(resultsDir = RESULTS_DIR, opts = {}) {
     const dir = resultsDir || RESULTS_DIR;
+    const { liveMode = false, liveStatus = null } = opts;
 
-    // Load all result files
+    // Load index — gracefully handle missing/empty for live mode
     const indexFile = path.join(dir, 'index.json');
-    if (!fs.existsSync(indexFile)) {
-        console.error(`No index.json found in ${dir}. Run the benchmark first.`);
+    let index = [];
+    try {
+        if (fs.existsSync(indexFile)) {
+            index = JSON.parse(fs.readFileSync(indexFile, 'utf8'));
+        }
+    } catch { }
+
+    if (index.length === 0 && !liveMode) {
+        console.error(`No benchmark results found in ${dir}. Run the benchmark first.`);
         process.exit(1);
     }
 
-    const index = JSON.parse(fs.readFileSync(indexFile, 'utf8'));
-    if (index.length === 0) {
-        console.error('No benchmark results found.');
-        process.exit(1);
-    }
-
-    // Load the latest result for detailed view
-    const latestEntry = index[index.length - 1];
-    const latestFile = path.join(dir, latestEntry.file);
-    const latest = JSON.parse(fs.readFileSync(latestFile, 'utf8'));
-
-    // Load all results for comparison
+    // Load all result files with full data
     const allResults = index.map(entry => {
         try {
             const data = JSON.parse(fs.readFileSync(path.join(dir, entry.file), 'utf8'));
             return { ...entry, data };
-        } catch { return entry; }
-    });
+        } catch { return { ...entry, data: null }; }
+    }).filter(r => r.data);
 
-    const html = buildHTML(latest, allResults);
+    // Load fixture images for Vision tab (base64)
+    const fixtureImages = {};
+    if (fs.existsSync(FIXTURES_DIR)) {
+        try {
+            const frames = fs.readdirSync(FIXTURES_DIR).filter(f => /\.(png|jpg|jpeg)$/i.test(f));
+            for (const f of frames) {
+                const imgPath = path.join(FIXTURES_DIR, f);
+                const ext = f.split('.').pop().toLowerCase();
+                const mime = ext === 'png' ? 'image/png' : 'image/jpeg';
+                const b64 = fs.readFileSync(imgPath).toString('base64');
+                fixtureImages[f] = `data:${mime};base64,${b64}`;
+            }
+        } catch (e) {
+            console.warn('  ⚠️  Could not load fixture images:', e.message);
+        }
+    }
+
+    const html = buildHTML(allResults, fixtureImages, { liveMode, liveStatus });
     const reportPath = path.join(dir, 'report.html');
     fs.writeFileSync(reportPath, html);
-    console.log(`  Report saved: ${reportPath}`);
-
-    // Try to open in browser
-    try {
-        const { execSync } = require('child_process');
-        if (process.platform === 'darwin') execSync(`open "${reportPath}"`);
-        else if (process.platform === 'linux') execSync(`xdg-open "${reportPath}"`);
-        else if (process.platform === 'win32') execSync(`start "" "${reportPath}"`);
-    } catch { }
+    // Suppress log noise during live updates
+    if (!liveMode) console.log(`  Report saved: ${reportPath}`);
 
     return reportPath;
 }
 
-function buildHTML(latest, allResults) {
-    const { totals, tokenTotals, model, system, suites } = latest;
-    const passRate = totals.total > 0 ? ((totals.passed / totals.total) * 100).toFixed(0) : 0;
-    const tokPerSec = totals.timeMs > 0 ? (tokenTotals.total / (totals.timeMs / 1000)).toFixed(1) : '?';
+function esc(str) {
+    return String(str || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
 
-    // Build suite rows
-    const suiteRows = suites.map(s => {
-        const pct = s.tests.length > 0 ? ((s.passed / s.tests.length) * 100).toFixed(0) : 0;
-        const color = s.failed === 0 ? '#22c55e' : s.passed > s.failed ? '#f59e0b' : '#ef4444';
-        return `<tr>
-            <td>${s.name}</td>
-            <td><span class="badge" style="background:${color}">${s.passed}/${s.tests.length}</span></td>
-            <td>${(s.timeMs / 1000).toFixed(1)}s</td>
-            <td><div class="bar-bg"><div class="bar" style="width:${pct}%;background:${color}"></div></div></td>
-        </tr>`;
-    }).join('\n');
+function buildHTML(allResults, fixtureImages, { liveMode = false, liveStatus = null } = {}) {
+    // Serialize data for embedded JS
+    const embeddedData = JSON.stringify(allResults.map(r => ({
+        file: r.file,
+        model: r.model,
+        vlm: r.vlm || r.data?.model?.vlm || null,
+        timestamp: r.timestamp || r.data?.timestamp,
+        passed: r.passed,
+        failed: r.failed,
+        total: r.total,
+        llmPassed: r.llmPassed,
+        llmTotal: r.llmTotal,
+        vlmPassed: r.vlmPassed,
+        vlmTotal: r.vlmTotal,
+        timeMs: r.timeMs,
+        tokens: r.tokens || r.data?.tokenTotals?.total,
+        perfSummary: r.perfSummary || r.data?.perfSummary || null,
+        system: r.data?.system || {},
+        tokenTotals: r.data?.tokenTotals || {},
+        suites: (r.data?.suites || []).map(s => ({
+            name: s.name,
+            passed: s.passed,
+            failed: s.failed,
+            skipped: s.skipped,
+            timeMs: s.timeMs,
+            tests: s.tests.map(t => ({
+                name: t.name,
+                status: t.status,
+                timeMs: t.timeMs,
+                detail: (t.detail || '').slice(0, 200),
+                tokens: t.tokens || {},
+                perf: t.perf || {},
+                fixture: t.fixture || null,
+                vlmResponse: t.vlmResponse || null,
+                vlmPrompt: t.vlmPrompt || null,
+            })),
+        })),
+    })));
 
-    // Build test detail rows
-    const testRows = suites.flatMap(s =>
-        s.tests.map(t => {
-            const icon = t.status === 'pass' ? '✅' : t.status === 'fail' ? '❌' : '⏭️';
-            const cls = t.status === 'fail' ? 'fail-row' : '';
-            return `<tr class="${cls}">
-                <td>${icon}</td>
-                <td class="suite-label">${s.name}</td>
-                <td>${t.name}</td>
-                <td>${t.timeMs}ms</td>
-                <td class="detail">${escHtml(t.detail.slice(0, 120))}</td>
-            </tr>`;
-        })
-    ).join('\n');
+    const fixtureJSON = JSON.stringify(fixtureImages);
 
-    // Build latency chart data (SVG bar chart)
-    const allTests = suites.flatMap(s => s.tests.filter(t => t.status !== 'skip'));
-    const maxLatency = Math.max(...allTests.map(t => t.timeMs), 1);
-    const barHeight = 22;
-    const chartHeight = allTests.length * (barHeight + 4) + 40;
-    const chartBars = allTests.map((t, i) => {
-        const w = (t.timeMs / maxLatency) * 500;
-        const y = i * (barHeight + 4) + 30;
-        const color = t.status === 'pass' ? '#22c55e' : '#ef4444';
-        const label = t.name.length > 30 ? t.name.slice(0, 28) + '…' : t.name;
-        return `<rect x="200" y="${y}" width="${w}" height="${barHeight}" fill="${color}" rx="3"/>
-        <text x="195" y="${y + 15}" text-anchor="end" class="chart-label">${escHtml(label)}</text>
-        <text x="${205 + w}" y="${y + 15}" class="chart-value">${t.timeMs}ms</text>`;
-    }).join('\n');
-
-    // Build historical comparison table
-    const historyRows = allResults.slice().reverse().map(r => {
-        const ts = new Date(r.timestamp).toLocaleDateString() + ' ' + new Date(r.timestamp).toLocaleTimeString();
-        const isCurrent = r.file === (allResults[allResults.length - 1]?.file);
-        const vlmModel = r.vlm || (r.data?.model?.vlm) || '';
-        const modelLabel = (r.model || '?') + (vlmModel ? `<br><span style="color:var(--muted);font-size:0.8em">VLM: ${vlmModel}</span>` : '');
-        // LLM/VLM split (fallback for older runs without split data)
-        const hasLlmVlm = r.llmTotal !== undefined;
-        const llmLabel = hasLlmVlm ? `${r.llmPassed}/${r.llmTotal}` : `${r.passed}/${r.total}`;
-        const llmPct = hasLlmVlm && r.llmTotal > 0 ? ((r.llmPassed / r.llmTotal) * 100).toFixed(0) + '%' : (r.total > 0 ? ((r.passed / r.total) * 100).toFixed(0) + '%' : '—');
-        const vlmLabel = hasLlmVlm && r.vlmTotal > 0 ? `${r.vlmPassed}/${r.vlmTotal}` : '—';
-        const vlmPct = hasLlmVlm && r.vlmTotal > 0 ? ((r.vlmPassed / r.vlmTotal) * 100).toFixed(0) + '%' : '—';
-        return `<tr${isCurrent ? ' class="current-run"' : ''}>
-            <td>${ts}${isCurrent ? ' ⬅️' : ''}</td>
-            <td>${modelLabel}</td>
-            <td>${llmLabel}</td>
-            <td>${llmPct}</td>
-            <td>${vlmLabel}</td>
-            <td>${vlmPct}</td>
-            <td>${(r.timeMs / 1000).toFixed(1)}s</td>
-            <td>${r.tokens || '?'}</td>
-        </tr>`;
-    }).join('\n');
+    // Live mode: auto-refresh meta tag
+    const refreshMeta = liveMode ? '<meta http-equiv="refresh" content="5">' : '';
+    const liveBannerHTML = liveMode ? buildLiveBanner(liveStatus) : '';
 
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Home Security AI Benchmark — ${model.name || 'Report'}</title>
+${refreshMeta}
+<title>HomeSec-Bench ${liveMode ? '🔴 LIVE' : 'Operations Center'}</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 <style>
 :root {
-    --bg: #0f172a; --card: #1e293b; --border: #334155;
-    --text: #e2e8f0; --muted: #94a3b8; --accent: #3b82f6;
-    --green: #22c55e; --red: #ef4444; --yellow: #f59e0b;
+    --bg: #0b1120; --bg2: #111827; --card: #1a2332; --card-hover: #1e293b;
+    --border: #2a3548; --border-light: #334155;
+    --text: #e2e8f0; --text-dim: #94a3b8; --text-muted: #64748b;
+    --accent: #3b82f6; --accent-glow: rgba(59,130,246,0.15);
+    --green: #22c55e; --green-dim: rgba(34,197,94,0.12);
+    --red: #ef4444; --red-dim: rgba(239,68,68,0.10);
+    --yellow: #f59e0b; --yellow-dim: rgba(245,158,11,0.12);
+    --purple: #a855f7; --cyan: #06b6d4;
+    --sidebar-w: 260px;
 }
 * { margin: 0; padding: 0; box-sizing: border-box; }
-body { font-family: 'Inter', -apple-system, system-ui, sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; }
-.container { max-width: 1100px; margin: 0 auto; padding: 2rem 1.5rem; }
-h1 { font-size: 1.8rem; font-weight: 700; margin-bottom: 0.25rem; }
-h2 { font-size: 1.2rem; font-weight: 600; margin: 2rem 0 1rem; color: var(--accent); border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
-.subtitle { color: var(--muted); font-size: 0.95rem; }
-.hero { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin: 1.5rem 0; }
-.stat-card { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 1.25rem; }
-.stat-card .label { color: var(--muted); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; }
-.stat-card .value { font-size: 2rem; font-weight: 700; margin-top: 0.25rem; }
-.stat-card .sub { color: var(--muted); font-size: 0.85rem; }
-table { width: 100%; border-collapse: collapse; margin: 1rem 0; }
-th, td { padding: 0.6rem 0.8rem; text-align: left; border-bottom: 1px solid var(--border); }
-th { color: var(--muted); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; }
-.badge { display: inline-block; padding: 0.15rem 0.6rem; border-radius: 999px; color: white; font-size: 0.85rem; font-weight: 600; }
-.bar-bg { background: var(--border); border-radius: 4px; height: 8px; width: 100px; }
-.bar { height: 8px; border-radius: 4px; transition: width 0.3s; }
-.fail-row { background: rgba(239, 68, 68, 0.08); }
-.detail { color: var(--muted); font-size: 0.8rem; max-width: 250px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.suite-label { color: var(--muted); font-size: 0.8rem; }
-.current-run { background: rgba(59, 130, 246, 0.08); }
-.chart-label { font-size: 11px; fill: var(--muted); }
-.chart-value { font-size: 11px; fill: var(--text); }
-.sys-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 0.5rem; }
-.sys-item { display: flex; gap: 0.5rem; }
-.sys-item .k { color: var(--muted); min-width: 100px; }
-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--border); color: var(--muted); font-size: 0.8rem; text-align: center; }
-@media (max-width: 640px) { .hero { grid-template-columns: 1fr 1fr; } }
+body { font-family: 'Inter', -apple-system, system-ui, sans-serif; background: var(--bg); color: var(--text); line-height: 1.5; overflow-x: hidden; }
+
+/* ─── Layout ─── */
+.app { display: flex; min-height: 100vh; }
+.sidebar {
+    width: var(--sidebar-w); min-width: var(--sidebar-w); background: var(--bg2);
+    border-right: 1px solid var(--border); padding: 1.25rem 0;
+    overflow-y: auto; position: fixed; top: 0; left: 0; bottom: 0; z-index: 10;
+}
+.main { margin-left: var(--sidebar-w); flex: 1; min-width: 0; }
+.header { padding: 1.25rem 2rem 0; }
+.content { padding: 1.5rem 2rem 3rem; }
+
+/* ─── Sidebar ─── */
+.sidebar-title {
+    font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em;
+    color: var(--text-muted); padding: 0 1rem 0.75rem; display: flex; align-items: center; gap: 0.5rem;
+}
+.sidebar-title::after { content: ''; flex: 1; height: 1px; background: var(--border); }
+.model-group { margin-bottom: 0.75rem; }
+.model-group-label {
+    font-size: 0.72rem; font-weight: 600; color: var(--text-dim);
+    padding: 0.35rem 1rem; cursor: pointer; display: flex; align-items: center; gap: 0.35rem;
+    user-select: none;
+}
+.model-group-label:hover { color: var(--text); }
+.model-group-label .arrow { font-size: 0.6rem; transition: transform 0.2s; }
+.model-group.collapsed .arrow { transform: rotate(-90deg); }
+.model-group.collapsed .run-list { display: none; }
+.run-item {
+    display: flex; align-items: center; gap: 0.5rem; padding: 0.3rem 1rem 0.3rem 1.5rem;
+    cursor: pointer; font-size: 0.78rem; color: var(--text-dim); transition: background 0.15s;
+    border-left: 2px solid transparent;
+}
+.run-item:hover { background: var(--accent-glow); color: var(--text); }
+.run-item.selected { background: var(--accent-glow); border-left-color: var(--accent); color: var(--text); }
+.run-item.primary { font-weight: 600; }
+.run-item input[type="checkbox"] { accent-color: var(--accent); cursor: pointer; }
+.run-meta { font-size: 0.68rem; color: var(--text-muted); }
+.run-score { margin-left: auto; font-size: 0.72rem; font-weight: 600; }
+.run-score.good { color: var(--green); }
+.run-score.mid { color: var(--yellow); }
+.run-score.bad { color: var(--red); }
+.sidebar-actions { padding: 0.75rem 1rem; border-top: 1px solid var(--border); }
+.btn {
+    display: inline-flex; align-items: center; gap: 0.35rem; padding: 0.45rem 0.85rem;
+    border-radius: 6px; font-size: 0.78rem; font-weight: 500; cursor: pointer;
+    border: 1px solid var(--border); background: var(--card); color: var(--text);
+    transition: all 0.15s;
+}
+.btn:hover { background: var(--card-hover); border-color: var(--accent); }
+.btn-primary { background: var(--accent); border-color: var(--accent); color: white; }
+.btn-primary:hover { background: #2563eb; }
+.btn-sm { padding: 0.3rem 0.6rem; font-size: 0.72rem; }
+.btn-block { width: 100%; justify-content: center; }
+
+/* ─── Tabs ─── */
+.tabs {
+    display: flex; gap: 0; border-bottom: 1px solid var(--border);
+    padding: 0 2rem;
+}
+.tab {
+    padding: 0.85rem 1.25rem; font-size: 0.85rem; font-weight: 500;
+    color: var(--text-muted); cursor: pointer; border-bottom: 2px solid transparent;
+    transition: all 0.15s; user-select: none;
+}
+.tab:hover { color: var(--text); }
+.tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+.tab-panel { display: none; }
+.tab-panel.active { display: block; }
+
+/* ─── Hero Cards ─── */
+.hero-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; margin-bottom: 1.5rem; }
+.stat-card {
+    background: var(--card); border: 1px solid var(--border); border-radius: 10px;
+    padding: 1rem 1.15rem; position: relative; overflow: hidden;
+}
+.stat-card::before {
+    content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+    background: linear-gradient(90deg, var(--accent), var(--cyan));
+}
+.stat-card .label { font-size: 0.7rem; font-weight: 500; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-muted); margin-bottom: 0.3rem; }
+.stat-card .value { font-size: 1.75rem; font-weight: 700; line-height: 1.1; }
+.stat-card .sub { font-size: 0.78rem; color: var(--text-dim); margin-top: 0.2rem; }
+
+/* ─── Tables ─── */
+.table-wrap { overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+th, td { padding: 0.55rem 0.75rem; text-align: left; border-bottom: 1px solid var(--border); }
+th { color: var(--text-muted); font-size: 0.72rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; white-space: nowrap; }
+tr:hover td { background: rgba(255,255,255,0.02); }
+.fail-row { background: var(--red-dim); }
+.badge { display: inline-block; padding: 0.12rem 0.5rem; border-radius: 999px; font-size: 0.75rem; font-weight: 600; color: white; }
+.bar-bg { background: var(--border); border-radius: 3px; height: 6px; width: 80px; display: inline-block; vertical-align: middle; }
+.bar-fill { height: 6px; border-radius: 3px; display: block; }
+
+/* ─── Charts ─── */
+.chart-container { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 1.25rem; margin-bottom: 1.5rem; }
+.chart-title { font-size: 0.82rem; font-weight: 600; margin-bottom: 1rem; color: var(--text-dim); }
+svg text { font-family: 'Inter', sans-serif; }
+
+/* ─── Vision Grid ─── */
+.vision-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1rem; }
+.vision-card {
+    background: var(--card); border: 1px solid var(--border); border-radius: 10px;
+    overflow: hidden; transition: transform 0.15s, box-shadow 0.15s;
+}
+.vision-card:hover { transform: translateY(-2px); box-shadow: 0 8px 24px rgba(0,0,0,0.3); }
+.vision-card img { width: 100%; height: 160px; object-fit: cover; display: block; }
+.vision-card .card-body { padding: 0.75rem 1rem; }
+.vision-card .card-title { font-size: 0.82rem; font-weight: 600; margin-bottom: 0.35rem; display: flex; align-items: center; gap: 0.4rem; }
+.vision-card .card-response { font-size: 0.72rem; color: var(--text-dim); line-height: 1.4; max-height: 3.6em; overflow: hidden; }
+.vision-card .card-prompt { font-size: 0.68rem; color: var(--text-muted); font-style: italic; margin-bottom: 0.25rem; }
+.no-img { width: 100%; height: 160px; background: var(--bg2); display: flex; align-items: center; justify-content: center; color: var(--text-muted); font-size: 0.8rem; }
+
+/* ─── Comparison ─── */
+.compare-table th.model-col { min-width: 140px; }
+.compare-table td.better { color: var(--green); font-weight: 600; }
+.compare-table td.worse { color: var(--red); }
+
+/* ─── Section ─── */
+.section-title { font-size: 0.95rem; font-weight: 600; margin: 1.5rem 0 0.75rem; padding-bottom: 0.4rem; border-bottom: 1px solid var(--border); color: var(--text); }
+
+/* ─── Export Toast ─── */
+.toast {
+    position: fixed; bottom: 2rem; right: 2rem; background: var(--green); color: white;
+    padding: 0.65rem 1.25rem; border-radius: 8px; font-size: 0.82rem; font-weight: 500;
+    opacity: 0; transform: translateY(10px); transition: all 0.3s;
+    z-index: 999; pointer-events: none;
+}
+.toast.show { opacity: 1; transform: translateY(0); }
+
+/* ─── Header ─── */
+.page-title { font-size: 1.4rem; font-weight: 700; display: flex; align-items: center; gap: 0.6rem; }
+.page-subtitle { color: var(--text-dim); font-size: 0.85rem; margin-top: 0.2rem; }
+
+/* ─── Empty state ─── */
+.empty-state { text-align: center; padding: 3rem; color: var(--text-muted); }
+.empty-state .icon { font-size: 2.5rem; margin-bottom: 0.75rem; }
+
+/* ─── Footer ─── */
+footer { padding: 1.5rem 2rem; border-top: 1px solid var(--border); color: var(--text-muted); font-size: 0.72rem; text-align: center; margin-left: var(--sidebar-w); }
+
+/* ─── Live Banner ─── */
+.live-banner {
+    background: linear-gradient(90deg, rgba(239,68,68,0.15), rgba(239,68,68,0.05));
+    border-bottom: 1px solid rgba(239,68,68,0.3);
+    padding: 0.6rem 2rem; font-size: 0.82rem;
+    display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap;
+    margin-left: var(--sidebar-w);
+}
+.live-dot {
+    width: 8px; height: 8px; border-radius: 50%; background: var(--red);
+    animation: livePulse 1.5s ease-in-out infinite;
+}
+@keyframes livePulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }
+.live-progress { width: 100%; height: 3px; background: var(--border); border-radius: 2px; margin-top: 0.3rem; }
+.live-progress-bar { height: 3px; background: var(--accent); border-radius: 2px; transition: width 0.3s; }
+
+/* ─── Responsive ─── */
+@media (max-width: 800px) {
+    .sidebar { width: 200px; min-width: 200px; --sidebar-w: 200px; }
+    .main { margin-left: 200px; }
+    .hero-grid { grid-template-columns: 1fr 1fr; }
+    .content { padding: 1rem; }
+}
 </style>
 </head>
 <body>
-<div class="container">
+${liveBannerHTML}
+<div class="app">
 
-<h1>🛡️ Home Security AI Benchmark</h1>
-<p class="subtitle">${new Date(latest.timestamp).toLocaleDateString()} ${new Date(latest.timestamp).toLocaleTimeString()}</p>
+<!-- ─── Sidebar ─── -->
+<aside class="sidebar" id="sidebar">
+    <div style="padding: 0 1rem 1rem; border-bottom: 1px solid var(--border); margin-bottom: 0.75rem;">
+        <div style="font-size: 0.95rem; font-weight: 700;">🛡️ HomeSec-Bench</div>
+        <div style="font-size: 0.7rem; color: var(--text-muted); margin-top: 0.15rem;">Operations Center</div>
+    </div>
+    <div class="sidebar-title">Run History</div>
+    <div id="run-list"></div>
+    <div class="sidebar-actions">
+        <button class="btn btn-primary btn-block" id="btn-compare" disabled>Compare Selected</button>
+        <button class="btn btn-block" id="btn-export" style="margin-top: 0.4rem;">📋 Export Markdown</button>
+    </div>
+</aside>
 
-<div class="hero">
-    <div class="stat-card">
-        <div class="label">Pass Rate</div>
-        <div class="value" style="color:${totals.failed === 0 ? 'var(--green)' : totals.passed > totals.failed ? 'var(--yellow)' : 'var(--red)'}"> ${passRate}%</div>
-        <div class="sub">${totals.passed}/${totals.total} tests passed</div>
+<!-- ─── Main ─── -->
+<div class="main">
+    <div class="tabs">
+        <div class="tab active" data-tab="performance">⚡ Performance</div>
+        <div class="tab" data-tab="quality">✅ Quality</div>
+        <div class="tab" data-tab="vision">🖼️ Vision</div>
     </div>
-    <div class="stat-card">
-        <div class="label">Total Time</div>
-        <div class="value">${(totals.timeMs / 1000).toFixed(1)}s</div>
-        <div class="sub">${suites.length} suites</div>
+
+    <div class="content">
+        <!-- ⚡ Performance Tab -->
+        <div class="tab-panel active" id="tab-performance"></div>
+
+        <!-- ✅ Quality Tab -->
+        <div class="tab-panel" id="tab-quality"></div>
+
+        <!-- 🖼️ Vision Tab -->
+        <div class="tab-panel" id="tab-vision"></div>
     </div>
-    <div class="stat-card">
-        <div class="label">Tokens</div>
-        <div class="value">${tokenTotals.total.toLocaleString()}</div>
-        <div class="sub">${tokPerSec} tok/s</div>
-    </div>
-    <div class="stat-card">
-        <div class="label">LLM</div>
-        <div class="value" style="font-size:1rem">${model.name || '?'}</div>
-        <div class="sub">${system.cpu || '?'}</div>
-    </div>${model.vlm ? `
-    <div class="stat-card">
-        <div class="label">VLM</div>
-        <div class="value" style="font-size:1rem">${model.vlm}</div>
-        <div class="sub">Vision Model</div>
-    </div>` : ''}
+
+    <footer>
+        Home Security AI Benchmark Suite • DeepCamera / SharpAI • Generated ${new Date().toISOString().slice(0, 19)}
+    </footer>
+</div>
 </div>
 
-<h2>Suite Summary</h2>
-<table>
-    <thead><tr><th>Suite</th><th>Result</th><th>Time</th><th>Pass Rate</th></tr></thead>
-    <tbody>${suiteRows}</tbody>
-</table>
+<div class="toast" id="toast"></div>
 
-<h2>Latency Chart</h2>
-<svg width="800" height="${chartHeight}" viewBox="0 0 800 ${chartHeight}" style="width:100%;max-width:800px">
-    <text x="400" y="18" text-anchor="middle" class="chart-label" style="font-size:13px;fill:var(--text)">Response Latency per Test (ms)</text>
-    ${chartBars}
-</svg>
+<script>
+// ═══════════════════════════════════════════════════════════════════════════════
+// EMBEDDED DATA
+// ═══════════════════════════════════════════════════════════════════════════════
+const ALL_RUNS = ${embeddedData};
+const FIXTURE_IMAGES = ${fixtureJSON};
 
-<h2>Test Details</h2>
-<table>
-    <thead><tr><th></th><th>Suite</th><th>Test</th><th>Time</th><th>Detail</th></tr></thead>
-    <tbody>${testRows}</tbody>
-</table>
+// ═══════════════════════════════════════════════════════════════════════════════
+// STATE
+// ═══════════════════════════════════════════════════════════════════════════════
+let selectedIndices = new Set([ALL_RUNS.length - 1]); // Latest run selected by default
+let primaryIndex = ALL_RUNS.length - 1;
+let compareMode = false;
 
-<h2>Token Usage</h2>
-<div class="hero">
-    <div class="stat-card">
-        <div class="label">Prompt Tokens</div>
-        <div class="value" style="font-size:1.5rem">${tokenTotals.prompt.toLocaleString()}</div>
-    </div>
-    <div class="stat-card">
-        <div class="label">Completion Tokens</div>
-        <div class="value" style="font-size:1.5rem">${tokenTotals.completion.toLocaleString()}</div>
-    </div>
-    <div class="stat-card">
-        <div class="label">Total Tokens</div>
-        <div class="value" style="font-size:1.5rem">${tokenTotals.total.toLocaleString()}</div>
-    </div>
-    <div class="stat-card">
-        <div class="label">Throughput</div>
-        <div class="value" style="font-size:1.5rem">${tokPerSec}</div>
-        <div class="sub">tokens/second</div>
-    </div>
-</div>
+// ═══════════════════════════════════════════════════════════════════════════════
+// UTILITIES
+// ═══════════════════════════════════════════════════════════════════════════════
+function fmt(n, d = 1) { return n != null ? Number(n).toFixed(d) : '—'; }
+function fmtInt(n) { return n != null ? Math.round(n) : '—'; }
+function fmtK(n) { return n >= 1000 ? (n / 1000).toFixed(1) + 'k' : String(n); }
+function pct(a, b) { return b > 0 ? ((a / b) * 100).toFixed(0) : '—'; }
+function scoreClass(passed, total) {
+    const r = total > 0 ? passed / total : 0;
+    return r >= 0.9 ? 'good' : r >= 0.6 ? 'mid' : 'bad';
+}
+function scoreColor(passed, total) {
+    const r = total > 0 ? passed / total : 0;
+    return r >= 0.9 ? 'var(--green)' : r >= 0.6 ? 'var(--yellow)' : 'var(--red)';
+}
+function shortDate(ts) {
+    if (!ts) return '—';
+    const d = new Date(ts);
+    return (d.getMonth() + 1) + '/' + d.getDate() + ' ' + d.getHours() + ':' + String(d.getMinutes()).padStart(2, '0');
+}
+function modelShort(name) {
+    if (!name) return '?';
+    return name.replace(/\\.gguf$/i, '').replace(/Qwen3\\.5-/i, 'Q3.5-');
+}
+function toast(msg) {
+    const el = document.getElementById('toast');
+    el.textContent = msg;
+    el.classList.add('show');
+    setTimeout(() => el.classList.remove('show'), 2500);
+}
+function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+function getSelected() { return [...selectedIndices].map(i => ALL_RUNS[i]).filter(Boolean); }
+function getPrimary() { return ALL_RUNS[primaryIndex]; }
 
-${allResults.length > 1 ? `<h2>Historical Comparison</h2>
-<table>
-    <thead><tr><th>Date</th><th>Model</th><th>LLM</th><th>LLM %</th><th>VLM</th><th>VLM %</th><th>Time</th><th>Tokens</th></tr></thead>
-    <tbody>${historyRows}</tbody>
-</table>` : ''}
+// ═══════════════════════════════════════════════════════════════════════════════
+// SIDEBAR — RUN LIST
+// ═══════════════════════════════════════════════════════════════════════════════
+function buildSidebar() {
+    const groups = {};
+    ALL_RUNS.forEach((r, idx) => {
+        // Group by model family (first two segments: e.g. "Qwen3.5-9B")
+        const parts = (r.model || '?').replace(/\\.gguf$/i, '').split('-');
+        const family = parts.slice(0, 2).join('-');
+        if (!groups[family]) groups[family] = [];
+        groups[family].push({ ...r, _idx: idx });
+    });
 
-<h2>System Configuration</h2>
-<div class="sys-grid">
-    <div class="sys-item"><span class="k">OS</span><span>${system.os || '?'}</span></div>
-    <div class="sys-item"><span class="k">CPU</span><span>${system.cpu || '?'}</span></div>
-    <div class="sys-item"><span class="k">Cores</span><span>${system.cpuCores || '?'}</span></div>
-    <div class="sys-item"><span class="k">RAM</span><span>${system.totalMemoryGB || '?'} GB total</span></div>
-    <div class="sys-item"><span class="k">Free RAM</span><span>${system.freeMemoryGB || '?'} GB</span></div>
-    <div class="sys-item"><span class="k">Node</span><span>${system.nodeVersion || '?'}</span></div>
-    <div class="sys-item"><span class="k">Process RSS</span><span>${system.processMemoryMB?.rss || '?'} MB</span></div>
-    <div class="sys-item"><span class="k">Heap Used</span><span>${system.processMemoryMB?.heapUsed || '?'} MB</span></div>
-</div>
+    let html = '';
+    for (const [family, runs] of Object.entries(groups)) {
+        html += '<div class="model-group">';
+        html += '<div class="model-group-label" onclick="this.parentElement.classList.toggle(\'collapsed\')"><span class="arrow">▾</span> ' + esc(family) + ' <span style="color:var(--text-muted);font-weight:400">(' + runs.length + ')</span></div>';
+        html += '<div class="run-list">';
+        for (const r of runs.reverse()) {
+            const sel = selectedIndices.has(r._idx);
+            const isPrimary = r._idx === primaryIndex;
+            const sc = scoreClass(r.passed, r.total);
+            html += '<div class="run-item' + (sel ? ' selected' : '') + (isPrimary ? ' primary' : '') + '" data-idx="' + r._idx + '">';
+            html += '<input type="checkbox"' + (sel ? ' checked' : '') + ' data-idx="' + r._idx + '">';
+            html += '<div><div style="font-size:0.78rem">' + esc(modelShort(r.model)) + '</div>';
+            html += '<div class="run-meta">' + shortDate(r.timestamp) + '</div></div>';
+            html += '<span class="run-score ' + sc + '">' + r.passed + '/' + r.total + '</span>';
+            html += '</div>';
+        }
+        html += '</div></div>';
+    }
+    document.getElementById('run-list').innerHTML = html;
 
-<footer>
-    Home Security AI Benchmark Suite • DeepCamera / SharpAI • Generated ${new Date().toISOString()}
-</footer>
+    // Bind events
+    document.querySelectorAll('.run-item').forEach(el => {
+        el.addEventListener('click', (e) => {
+            if (e.target.type === 'checkbox') return;
+            const idx = parseInt(el.dataset.idx);
+            primaryIndex = idx;
+            if (!selectedIndices.has(idx)) selectedIndices.add(idx);
+            refresh();
+        });
+    });
+    document.querySelectorAll('.run-item input[type="checkbox"]').forEach(cb => {
+        cb.addEventListener('change', (e) => {
+            const idx = parseInt(cb.dataset.idx);
+            if (cb.checked) selectedIndices.add(idx);
+            else selectedIndices.delete(idx);
+            if (selectedIndices.size === 0) { selectedIndices.add(primaryIndex); }
+            refresh();
+        });
+    });
+}
 
-</div>
+function updateCompareBtn() {
+    const btn = document.getElementById('btn-compare');
+    const n = selectedIndices.size;
+    btn.textContent = n > 1 ? 'Comparing ' + n + ' Runs' : 'Select 2+ to Compare';
+    btn.disabled = n < 2;
+    compareMode = n > 1;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TAB: PERFORMANCE
+// ═══════════════════════════════════════════════════════════════════════════════
+function renderPerformance() {
+    const run = getPrimary();
+    const perf = run.perfSummary;
+    const sel = getSelected();
+
+    let html = '<div class="header"><div class="page-title">⚡ Performance</div>';
+    html += '<div class="page-subtitle">' + esc(run.model || '?') + ' — ' + shortDate(run.timestamp) + '</div></div>';
+
+    // Hero cards
+    html += '<div class="hero-grid">';
+    const ttftAvg = perf?.ttft?.avgMs;
+    const ttftP50 = perf?.ttft?.p50Ms;
+    const ttftP95 = perf?.ttft?.p95Ms;
+    const decAvg = perf?.decode?.avgTokensPerSec;
+    const srvPrefill = perf?.server?.prefillTokensPerSec;
+    const srvDecode = perf?.server?.decodeTokensPerSec;
+    const totalTime = run.timeMs;
+    const tokPerSec = totalTime > 0 && run.tokens ? (run.tokens / (totalTime / 1000)).toFixed(1) : null;
+
+    html += statCard('TTFT (avg)', fmtInt(ttftAvg), 'ms', ttftP50 != null ? 'p50: ' + fmtInt(ttftP50) + 'ms · p95: ' + fmtInt(ttftP95) + 'ms' : 'No data — run with --metrics');
+    html += statCard('Decode Speed', fmt(decAvg), 'tok/s', 'Client-measured generation');
+    html += statCard('Server Prefill', fmt(srvPrefill), 'tok/s', 'From llama-server /metrics');
+    html += statCard('Server Decode', fmt(srvDecode), 'tok/s', 'From llama-server /metrics');
+    html += statCard('Total Time', fmt(totalTime / 1000), 's', run.total + ' tests');
+    html += statCard('Throughput', fmt(tokPerSec), 'tok/s', fmtK(run.tokens || 0) + ' total tokens');
+    html += '</div>';
+
+    // Comparison table if multiple selected
+    if (sel.length > 1) {
+        html += '<div class="section-title">Performance Comparison</div>';
+        html += '<div class="table-wrap"><table class="compare-table"><thead><tr><th>Metric</th>';
+        for (const r of sel) html += '<th class="model-col">' + esc(modelShort(r.model)) + '<br><span style="font-weight:400;font-size:0.68rem">' + shortDate(r.timestamp) + '</span></th>';
+        html += '</tr></thead><tbody>';
+        const metrics = [
+            ['TTFT avg (ms)', r => fmtInt(r.perfSummary?.ttft?.avgMs)],
+            ['TTFT p50 (ms)', r => fmtInt(r.perfSummary?.ttft?.p50Ms)],
+            ['TTFT p95 (ms)', r => fmtInt(r.perfSummary?.ttft?.p95Ms)],
+            ['Decode (tok/s)', r => fmt(r.perfSummary?.decode?.avgTokensPerSec)],
+            ['Server Prefill (tok/s)', r => fmt(r.perfSummary?.server?.prefillTokensPerSec)],
+            ['Server Decode (tok/s)', r => fmt(r.perfSummary?.server?.decodeTokensPerSec)],
+            ['Total Time (s)', r => fmt(r.timeMs / 1000)],
+            ['Total Tokens', r => fmtK(r.tokens || 0)],
+        ];
+        for (const [label, fn] of metrics) {
+            html += '<tr><td style="font-weight:500">' + label + '</td>';
+            const vals = sel.map(fn);
+            for (const v of vals) html += '<td>' + v + '</td>';
+            html += '</tr>';
+        }
+        html += '</tbody></table></div>';
+    }
+
+    // Trend chart: TTFT across all runs
+    html += renderTrendChart('TTFT Trend (avg ms)', ALL_RUNS, r => r.perfSummary?.ttft?.avgMs, 'ms');
+    html += renderTrendChart('Decode Speed Trend (tok/s)', ALL_RUNS, r => r.perfSummary?.decode?.avgTokensPerSec, 'tok/s');
+
+    document.getElementById('tab-performance').innerHTML = html;
+}
+
+function statCard(label, value, unit, sub) {
+    return '<div class="stat-card"><div class="label">' + label + '</div><div class="value">' + value + ' <span style="font-size:0.9rem;font-weight:400;color:var(--text-dim)">' + (unit || '') + '</span></div><div class="sub">' + (sub || '') + '</div></div>';
+}
+
+function renderTrendChart(title, runs, accessor, unit) {
+    const data = runs.map((r, i) => ({ x: i, y: accessor(r), label: modelShort(r.model) }));
+    const valid = data.filter(d => d.y != null);
+    if (valid.length < 2) return '';
+
+    const W = 700, H = 180, PAD = 50, PADT = 25, PADR = 20;
+    const maxY = Math.max(...valid.map(d => d.y)) * 1.15;
+    const minY = 0;
+    const xScale = (W - PAD - PADR) / (data.length - 1 || 1);
+    const yScale = (H - PADT - 30) / (maxY - minY || 1);
+
+    let pts = '';
+    let dots = '';
+    let first = true;
+    for (const d of data) {
+        if (d.y == null) continue;
+        const cx = PAD + d.x * xScale;
+        const cy = H - 30 - (d.y - minY) * yScale;
+        pts += (first ? 'M' : 'L') + cx + ',' + cy;
+        const isSel = selectedIndices.has(d.x);
+        dots += '<circle cx="' + cx + '" cy="' + cy + '" r="' + (isSel ? 4 : 2.5) + '" fill="' + (isSel ? 'var(--accent)' : 'var(--text-muted)') + '"/>';
+        if (isSel) dots += '<text x="' + cx + '" y="' + (cy - 8) + '" text-anchor="middle" style="font-size:9px;fill:var(--text)">' + fmt(d.y) + '</text>';
+        first = false;
+    }
+
+    // Y-axis labels
+    let yLabels = '';
+    const steps = 4;
+    for (let i = 0; i <= steps; i++) {
+        const v = minY + (maxY - minY) * (i / steps);
+        const y = H - 30 - (v - minY) * yScale;
+        yLabels += '<text x="' + (PAD - 6) + '" y="' + (y + 3) + '" text-anchor="end" style="font-size:9px;fill:var(--text-muted)">' + fmtInt(v) + '</text>';
+        yLabels += '<line x1="' + PAD + '" y1="' + y + '" x2="' + (W - PADR) + '" y2="' + y + '" stroke="var(--border)" stroke-dasharray="3,3"/>';
+    }
+
+    return '<div class="chart-container"><div class="chart-title">' + title + '</div>' +
+        '<svg width="' + W + '" height="' + H + '" viewBox="0 0 ' + W + ' ' + H + '" style="width:100%;max-width:' + W + 'px">' +
+        yLabels +
+        '<path d="' + pts + '" fill="none" stroke="var(--accent)" stroke-width="2" stroke-linejoin="round"/>' +
+        dots +
+        '</svg></div>';
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TAB: QUALITY
+// ═══════════════════════════════════════════════════════════════════════════════
+function renderQuality() {
+    const run = getPrimary();
+    const sel = getSelected();
+    const { suites } = run;
+    const passRate = run.total > 0 ? ((run.passed / run.total) * 100).toFixed(0) : 0;
+
+    let html = '<div class="header"><div class="page-title">✅ Quality</div>';
+    html += '<div class="page-subtitle">' + esc(run.model || '?') + ' — ' + passRate + '% pass rate (' + run.passed + '/' + run.total + ')</div></div>';
+
+    // Hero cards
+    html += '<div class="hero-grid">';
+    html += statCard('Pass Rate', passRate, '%', run.passed + '/' + run.total + ' tests');
+    html += statCard('LLM Score', run.llmTotal > 0 ? pct(run.llmPassed, run.llmTotal) : '—', '%', (run.llmPassed || 0) + '/' + (run.llmTotal || 0));
+    html += statCard('VLM Score', run.vlmTotal > 0 ? pct(run.vlmPassed, run.vlmTotal) : '—', '%', (run.vlmPassed || 0) + '/' + (run.vlmTotal || 0));
+    html += statCard('Failed', String(run.failed), '', run.total + ' total tests');
+    html += '</div>';
+
+    // Multi-run comparison
+    if (sel.length > 1) {
+        html += '<div class="section-title">Quality Comparison</div>';
+        html += '<div class="table-wrap"><table class="compare-table"><thead><tr><th>Suite</th>';
+        for (const r of sel) html += '<th class="model-col">' + esc(modelShort(r.model)) + '</th>';
+        html += '</tr></thead><tbody>';
+        // Get union of all suite names
+        const allSuiteNames = [...new Set(sel.flatMap(r => r.suites.map(s => s.name)))];
+        for (const sname of allSuiteNames) {
+            html += '<tr><td>' + esc(sname) + '</td>';
+            for (const r of sel) {
+                const s = r.suites.find(x => x.name === sname);
+                if (s) {
+                    const total = s.tests.length;
+                    const color = scoreColor(s.passed, total);
+                    html += '<td><span class="badge" style="background:' + color + '">' + s.passed + '/' + total + '</span></td>';
+                } else {
+                    html += '<td style="color:var(--text-muted)">—</td>';
+                }
+            }
+            html += '</tr>';
+        }
+        html += '</tbody></table></div>';
+    }
+
+    // Suite summary
+    html += '<div class="section-title">Suite Summary</div>';
+    html += '<div class="table-wrap"><table><thead><tr><th>Suite</th><th>Result</th><th>Time</th><th>Pass Rate</th></tr></thead><tbody>';
+    for (const s of suites) {
+        const total = s.tests.length;
+        const pctV = total > 0 ? ((s.passed / total) * 100).toFixed(0) : 0;
+        const color = scoreColor(s.passed, total);
+        html += '<tr><td>' + esc(s.name) + '</td>';
+        html += '<td><span class="badge" style="background:' + color + '">' + s.passed + '/' + total + '</span></td>';
+        html += '<td>' + fmt(s.timeMs / 1000) + 's</td>';
+        html += '<td><div class="bar-bg"><span class="bar-fill" style="width:' + pctV + '%;background:' + color + '"></span></div> ' + pctV + '%</td>';
+        html += '</tr>';
+    }
+    html += '</tbody></table></div>';
+
+    // Test details
+    html += '<div class="section-title">Test Details</div>';
+    html += '<div class="table-wrap"><table><thead><tr><th></th><th>Suite</th><th>Test</th><th>Time</th><th>Detail</th></tr></thead><tbody>';
+    for (const s of suites) {
+        for (const t of s.tests) {
+            const icon = t.status === 'pass' ? '✅' : t.status === 'fail' ? '❌' : '⏭️';
+            const cls = t.status === 'fail' ? ' class="fail-row"' : '';
+            html += '<tr' + cls + '><td>' + icon + '</td>';
+            html += '<td style="color:var(--text-muted);font-size:0.75rem">' + esc(s.name) + '</td>';
+            html += '<td>' + esc(t.name) + '</td>';
+            html += '<td>' + t.timeMs + 'ms</td>';
+            html += '<td style="color:var(--text-dim);font-size:0.75rem;max-width:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + esc(t.detail) + '</td>';
+            html += '</tr>';
+        }
+    }
+    html += '</tbody></table></div>';
+
+    document.getElementById('tab-quality').innerHTML = html;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TAB: VISION
+// ═══════════════════════════════════════════════════════════════════════════════
+function renderVision() {
+    const run = getPrimary();
+    const sel = getSelected();
+
+    // Collect VLM tests (from all suites — VLM Scene Analysis + VLM-to-Alert Triage)
+    const vlmTests = [];
+    for (const s of run.suites) {
+        for (const t of s.tests) {
+            if (t.fixture) vlmTests.push({ ...t, suite: s.name });
+        }
+    }
+
+    let html = '<div class="header"><div class="page-title">🖼️ Vision</div>';
+    html += '<div class="page-subtitle">' + esc(run.model || '?') + ' — ' + vlmTests.length + ' VLM image tests</div></div>';
+
+    if (vlmTests.length === 0) {
+        html += '<div class="empty-state"><div class="icon">📷</div>';
+        html += '<div>No VLM image test data in this run.</div>';
+        html += '<div style="font-size:0.82rem;margin-top:0.5rem">Run the benchmark with <code>--vlm URL</code> to enable VLM scene analysis.</div></div>';
+        document.getElementById('tab-vision').innerHTML = html;
+        return;
+    }
+
+    // Multi-run comparison mode for vision
+    if (sel.length > 1) {
+        html += '<div class="section-title">VLM Comparison — ' + sel.length + ' Runs</div>';
+        html += '<div class="table-wrap"><table><thead><tr><th>Image</th><th>Test</th>';
+        for (const r of sel) html += '<th>' + esc(modelShort(r.model)) + '</th>';
+        html += '</tr></thead><tbody>';
+        for (const vt of vlmTests) {
+            html += '<tr>';
+            const imgSrc = vt.fixture && FIXTURE_IMAGES[vt.fixture];
+            html += '<td>' + (imgSrc ? '<img src="' + imgSrc + '" style="width:60px;height:40px;object-fit:cover;border-radius:4px">' : '—') + '</td>';
+            html += '<td style="font-size:0.78rem">' + esc(vt.name) + '</td>';
+            for (const r of sel) {
+                const match = r.suites.flatMap(s => s.tests).find(t => t.fixture === vt.fixture);
+                if (match) {
+                    const icon = match.status === 'pass' ? '✅' : '❌';
+                    html += '<td>' + icon + ' <span style="font-size:0.7rem;color:var(--text-dim)">' + esc((match.vlmResponse || match.detail || '').slice(0, 60)) + '</span></td>';
+                } else {
+                    html += '<td style="color:var(--text-muted)">—</td>';
+                }
+            }
+            html += '</tr>';
+        }
+        html += '</tbody></table></div>';
+    }
+
+    // Image grid
+    html += '<div class="section-title">Scene Analysis Results</div>';
+    html += '<div class="vision-grid">';
+    for (const t of vlmTests) {
+        const imgSrc = t.fixture && FIXTURE_IMAGES[t.fixture];
+        const statusBadge = t.status === 'pass'
+            ? '<span class="badge" style="background:var(--green)">Pass</span>'
+            : '<span class="badge" style="background:var(--red)">Fail</span>';
+        html += '<div class="vision-card">';
+        if (imgSrc) {
+            html += '<img src="' + imgSrc + '" alt="' + esc(t.name) + '" loading="lazy">';
+        } else {
+            html += '<div class="no-img">🖼️ ' + esc(t.fixture || 'No image') + '</div>';
+        }
+        html += '<div class="card-body">';
+        html += '<div class="card-title">' + statusBadge + ' ' + esc(t.name) + '</div>';
+        if (t.vlmPrompt) html += '<div class="card-prompt">"' + esc(t.vlmPrompt.slice(0, 80)) + '"</div>';
+        if (t.vlmResponse) {
+            html += '<div class="card-response">' + esc(t.vlmResponse) + '</div>';
+        } else if (t.detail) {
+            html += '<div class="card-response">' + esc(t.detail) + '</div>';
+        }
+        html += '</div></div>';
+    }
+    html += '</div>';
+
+    document.getElementById('tab-vision').innerHTML = html;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// EXPORT MARKDOWN
+// ═══════════════════════════════════════════════════════════════════════════════
+function exportMarkdown() {
+    const sel = getSelected();
+    if (sel.length === 0) return;
+
+    let md = '## HomeSec-Bench Results\\n\\n';
+
+    if (sel.length === 1) {
+        const r = sel[0];
+        md += '**Model:** ' + (r.model || '?') + '\\n';
+        md += '**Date:** ' + new Date(r.timestamp).toISOString().slice(0, 10) + '\\n\\n';
+        md += '| Metric | Value |\\n|--------|-------|\\n';
+        md += '| Pass Rate | ' + pct(r.passed, r.total) + '% (' + r.passed + '/' + r.total + ') |\\n';
+        md += '| LLM Score | ' + pct(r.llmPassed, r.llmTotal) + '% |\\n';
+        if (r.vlmTotal > 0) md += '| VLM Score | ' + pct(r.vlmPassed, r.vlmTotal) + '% |\\n';
+        md += '| Total Time | ' + fmt(r.timeMs / 1000) + 's |\\n';
+        md += '| Tokens | ' + fmtK(r.tokens || 0) + ' |\\n';
+        if (r.perfSummary?.ttft?.avgMs) md += '| TTFT avg | ' + fmtInt(r.perfSummary.ttft.avgMs) + 'ms |\\n';
+        if (r.perfSummary?.decode?.avgTokensPerSec) md += '| Decode | ' + fmt(r.perfSummary.decode.avgTokensPerSec) + ' tok/s |\\n';
+    } else {
+        md += '| Metric |';
+        for (const r of sel) md += ' ' + (r.model || '?').replace(/\\.gguf$/i, '') + ' |';
+        md += '\\n|--------|';
+        for (const r of sel) md += '--------|';
+        md += '\\n';
+        const rows = [
+            ['Pass Rate', r => pct(r.passed, r.total) + '%'],
+            ['LLM', r => r.llmTotal > 0 ? pct(r.llmPassed, r.llmTotal) + '%' : '—'],
+            ['VLM', r => r.vlmTotal > 0 ? pct(r.vlmPassed, r.vlmTotal) + '%' : '—'],
+            ['Time', r => fmt(r.timeMs / 1000) + 's'],
+            ['Tokens', r => fmtK(r.tokens || 0)],
+            ['TTFT', r => r.perfSummary?.ttft?.avgMs != null ? fmtInt(r.perfSummary.ttft.avgMs) + 'ms' : '—'],
+            ['Decode', r => r.perfSummary?.decode?.avgTokensPerSec != null ? fmt(r.perfSummary.decode.avgTokensPerSec) + ' tok/s' : '—'],
+        ];
+        for (const [label, fn] of rows) {
+            md += '| ' + label + ' |';
+            for (const r of sel) md += ' ' + fn(r) + ' |';
+            md += '\\n';
+        }
+    }
+
+    md += '\\n*Generated by HomeSec-Bench Operations Center*\\n';
+
+    // Copy to clipboard
+    const textarea = document.createElement('textarea');
+    textarea.value = md.replace(/\\\\n/g, '\\n');
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+    toast('📋 Markdown copied to clipboard');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TAB SWITCHING
+// ═══════════════════════════════════════════════════════════════════════════════
+document.querySelectorAll('.tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+        document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+        document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+        tab.classList.add('active');
+        document.getElementById('tab-' + tab.dataset.tab).classList.add('active');
+        renderActiveTab();
+    });
+});
+
+function getActiveTab() {
+    return document.querySelector('.tab.active')?.dataset.tab || 'performance';
+}
+
+function renderActiveTab() {
+    const tab = getActiveTab();
+    if (tab === 'performance') renderPerformance();
+    else if (tab === 'quality') renderQuality();
+    else if (tab === 'vision') renderVision();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// REFRESH (called on selection change)
+// ═══════════════════════════════════════════════════════════════════════════════
+function refresh() {
+    buildSidebar();
+    updateCompareBtn();
+    renderActiveTab();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// INIT
+// ═══════════════════════════════════════════════════════════════════════════════
+document.getElementById('btn-export').addEventListener('click', exportMarkdown);
+document.getElementById('btn-compare').addEventListener('click', () => {
+    // Toggle compare mode info
+    if (selectedIndices.size > 1) renderActiveTab();
+});
+
+refresh();
+</script>
 </body>
 </html>`;
 }
@@ -286,6 +859,23 @@ function escHtml(str) {
 // Run if called directly
 if (require.main === module) {
     generateReport();
+}
+
+function buildLiveBanner(status) {
+    if (!status) {
+        return `<div class="live-banner"><span class="live-dot"></span> Benchmark starting\u2026</div>`;
+    }
+    const { suitesCompleted = 0, totalSuites = 0, currentSuite = '', startedAt = '' } = status;
+    const pct = totalSuites > 0 ? Math.round((suitesCompleted / totalSuites) * 100) : 0;
+    const elapsed = startedAt ? Math.round((Date.now() - new Date(startedAt).getTime()) / 1000) : 0;
+    const elapsedStr = elapsed > 60 ? Math.floor(elapsed / 60) + 'm ' + (elapsed % 60) + 's' : elapsed + 's';
+    return `<div class="live-banner">
+        <span class="live-dot"></span>
+        <strong>LIVE</strong> — Suite ${suitesCompleted}/${totalSuites} (${pct}%)
+        ${currentSuite ? ' — <em>' + currentSuite + '</em>' : ''}
+        <span style="margin-left:auto;font-size:0.78rem">${elapsedStr} elapsed</span>
+        <div class="live-progress"><div class="live-progress-bar" style="width:${pct}%"></div></div>
+    </div>`;
 }
 
 module.exports = { generateReport };

--- a/skills/analysis/home-security-benchmark/scripts/run-benchmark.cjs
+++ b/skills/analysis/home-security-benchmark/scripts/run-benchmark.cjs
@@ -505,8 +505,79 @@ function assert(condition, msg) {
     if (!condition) throw new Error(msg || 'Assertion failed');
 }
 
+// ─── Live progress: intermediate saves + report regeneration ────────────────
+let _liveReportOpened = false;
+
+/**
+ * Save the current (in-progress) results to disk and regenerate the live report.
+ * Called after each suite completes so the browser auto-refreshes with updated data.
+ */
+function saveLiveProgress(startedAt, suitesCompleted, totalSuites, nextSuiteName) {
+    try {
+        fs.mkdirSync(RESULTS_DIR, { recursive: true });
+
+        // Save current results as a live file (will be overwritten each time)
+        const liveFile = path.join(RESULTS_DIR, '_live_progress.json');
+        const liveResults = {
+            ...results,
+            _live: true,
+            _progress: { suitesCompleted, totalSuites, startedAt },
+        };
+        fs.writeFileSync(liveFile, JSON.stringify(liveResults, null, 2));
+
+        // Build a temporary index with just the live file
+        const indexFile = path.join(RESULTS_DIR, 'index.json');
+        const liveIndex = [{
+            file: '_live_progress.json',
+            model: results.model.name || 'loading...',
+            vlm: results.model.vlm || null,
+            timestamp: results.timestamp,
+            passed: results.totals.passed,
+            failed: results.totals.failed,
+            total: results.totals.total,
+            llmPassed: results.totals.passed, // Simplified for live view
+            llmTotal: results.totals.total,
+            vlmPassed: 0, vlmTotal: 0,
+            timeMs: Date.now() - new Date(startedAt).getTime(),
+            tokens: results.tokenTotals.total,
+            perfSummary: null,
+        }];
+        fs.writeFileSync(indexFile, JSON.stringify(liveIndex, null, 2));
+
+        // Regenerate report in live mode
+        const reportScript = path.join(__dirname, 'generate-report.cjs');
+        // Clear require cache to pick up any code changes
+        delete require.cache[require.resolve(reportScript)];
+        const { generateReport } = require(reportScript);
+        const reportPath = generateReport(RESULTS_DIR, {
+            liveMode: true,
+            liveStatus: {
+                suitesCompleted,
+                totalSuites,
+                currentSuite: nextSuiteName || 'Finishing...',
+                startedAt,
+            },
+        });
+
+        // Open browser on first save (so user sees live progress from the start)
+        if (!_liveReportOpened && !NO_OPEN && !IS_SKILL_MODE && reportPath) {
+            try {
+                const openCmd = process.platform === 'darwin' ? 'open' : 'xdg-open';
+                execSync(`${openCmd} "${reportPath}"`, { stdio: 'ignore' });
+                log('  📊 Live report opened in browser (auto-refreshes every 5s)');
+            } catch { }
+            _liveReportOpened = true;
+        }
+    } catch (err) {
+        // Non-fatal — live progress is a nice-to-have
+        log(`  ⚠️  Live progress update failed: ${err.message}`);
+    }
+}
+
 async function runSuites() {
-    for (const s of suites) {
+    const startedAt = new Date().toISOString();
+    for (let si = 0; si < suites.length; si++) {
+        const s = suites[si];
         currentSuite = { name: s.name, tests: [], passed: 0, failed: 0, skipped: 0, timeMs: 0 };
         log(`\n${'─'.repeat(60)}`);
         log(`  ${s.name}`);
@@ -522,12 +593,16 @@ async function runSuites() {
         results.totals.total += currentSuite.tests.length;
 
         emit({ event: 'suite_end', suite: s.name, passed: currentSuite.passed, failed: currentSuite.failed, skipped: currentSuite.skipped, timeMs: currentSuite.timeMs });
+
+        // Live progress: save intermediate results + regenerate report after each suite
+        saveLiveProgress(startedAt, si + 1, suites.length, si + 1 < suites.length ? suites[si + 1]?.name : null);
     }
 }
 
 // ─── Per-test token + perf accumulators (set by test(), read by llmCall) ──────
 let _currentTestTokens = null;
 let _currentTestPerf = null;
+let _vlmTestMeta = null; // VLM fixture metadata (set during VLM tests, read after test() completes)
 
 async function test(name, fn) {
     const testResult = { name, status: 'pass', timeMs: 0, detail: '', tokens: { prompt: 0, completion: 0, total: 0 }, perf: {} };
@@ -2025,18 +2100,37 @@ suite('📸 VLM Scene Analysis', async () => {
             const framePath = path.join(FIXTURES_DIR, 'frames', t.file);
             if (!fs.existsSync(framePath)) { skip(t.name, `File missing: ${t.file}`); return; }
             const desc = await vlmAnalyze(framePath, t.prompt);
-            if (t.expect === null) {
-                // Just check we got a meaningful response
-                assert(desc.length > 20, `Response too short: ${desc.length} chars`);
-                return `${desc.length} chars ✓`;
-            }
-            const lower = desc.toLowerCase();
-            const matched = t.expect.some(term => lower.includes(term));
-            assert(matched,
-                `Expected one of [${t.expect.slice(0, 4).join(', ')}...] in: "${desc.slice(0, 80)}"`);
-            const hits = t.expect.filter(term => lower.includes(term));
-            return `${desc.length} chars, matched: ${hits.join(', ')} ✓`;
+
+            // Save fixture filename + VLM response for Vision tab in report
+            const lastTest = currentSuite.tests.length > 0 ? null : undefined; // will be set after push
+            // Attach after test() pushes — use a post-hook via the return
+            const result = (() => {
+                if (t.expect === null) {
+                    assert(desc.length > 20, `Response too short: ${desc.length} chars`);
+                    return `${desc.length} chars ✓`;
+                }
+                const lower = desc.toLowerCase();
+                const matched = t.expect.some(term => lower.includes(term));
+                assert(matched,
+                    `Expected one of [${t.expect.slice(0, 4).join(', ')}...] in: "${desc.slice(0, 80)}"`);
+                const hits = t.expect.filter(term => lower.includes(term));
+                return `${desc.length} chars, matched: ${hits.join(', ')} ✓`;
+            })();
+
+            // Stash fixture + response on the test result (test() pushes to currentSuite.tests)
+            // We set it as a closure-accessible value; the test() function reads the return value.
+            // After test() completes, we patch the last test entry with VLM metadata.
+            _vlmTestMeta = { fixture: t.file, vlmResponse: desc.slice(0, 300), prompt: t.prompt };
+            return result;
         });
+        // Patch the last pushed test with VLM metadata (fixture filename + response preview)
+        if (_vlmTestMeta && currentSuite.tests.length > 0) {
+            const lastTest = currentSuite.tests[currentSuite.tests.length - 1];
+            lastTest.fixture = _vlmTestMeta.fixture;
+            lastTest.vlmResponse = _vlmTestMeta.vlmResponse;
+            lastTest.vlmPrompt = _vlmTestMeta.prompt;
+            _vlmTestMeta = null;
+        }
     }
 });
 
@@ -2233,16 +2327,18 @@ async function main() {
 
     // Save results
     fs.mkdirSync(RESULTS_DIR, { recursive: true });
+    // Clean up live progress file (replaced by final results)
+    try { fs.unlinkSync(path.join(RESULTS_DIR, '_live_progress.json')); } catch { }
     const modelSlug = (results.model.name || 'unknown').replace(/[^a-zA-Z0-9_.-]/g, '_');
     const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
     const resultFile = path.join(RESULTS_DIR, `${modelSlug}_${ts}.json`);
     fs.writeFileSync(resultFile, JSON.stringify(results, null, 2));
     log(`\n  Results saved: ${resultFile}`);
 
-    // Update index
+    // Update index (filter out any live progress entries)
     const indexFile = path.join(RESULTS_DIR, 'index.json');
     let index = [];
-    try { index = JSON.parse(fs.readFileSync(indexFile, 'utf8')); } catch { }
+    try { index = JSON.parse(fs.readFileSync(indexFile, 'utf8')).filter(e => e.file !== '_live_progress.json'); } catch { }
     // Compute LLM vs VLM split (only count image analysis suites as VLM)
     const isVlmImageSuite = (name) => name.includes('VLM Scene') || name.includes('📸');
     const vlmSuites = results.suites.filter(s => isVlmImageSuite(s.name));
@@ -2265,16 +2361,19 @@ async function main() {
     });
     fs.writeFileSync(indexFile, JSON.stringify(index, null, 2));
 
-    // Always generate report (skip only on explicit --no-open with no --report flag)
+    // Always generate final report (without live mode) 
     let reportPath = null;
     log('\n  Generating HTML report...');
     try {
         const reportScript = path.join(__dirname, 'generate-report.cjs');
+        // Clear require cache to get latest version  
+        delete require.cache[require.resolve(reportScript)];
         reportPath = require(reportScript).generateReport(RESULTS_DIR);
         log(`  ✅ Report: ${reportPath}`);
 
         // Auto-open in browser — only in standalone mode (Aegis handles its own opening)
-        if (!NO_OPEN && !IS_SKILL_MODE && reportPath) {
+        // Skip if live mode already opened the browser earlier
+        if (!_liveReportOpened && !NO_OPEN && !IS_SKILL_MODE && reportPath) {
             try {
                 const openCmd = process.platform === 'darwin' ? 'open' : 'xdg-open';
                 execSync(`${openCmd} "${reportPath}"`, { stdio: 'ignore' });


### PR DESCRIPTION
- Redesign generate-report.cjs as a multi-view Operations Center
  - Three tabs: Performance, Quality, Vision
  - Run picker sidebar with model-grouped history + multi-select
  - Comparison tables across selected runs
  - Export to Markdown for community sharing
- Add live progress mode (auto-refresh + LIVE banner)
  - Intermediate saves after each suite completes
  - Browser auto-opens with pulsing progress indicator
  - Auto-refreshes every 5s during benchmark run
- Save VLM fixture metadata (filename, response, prompt) per test
- Embed all data inline for fully self-contained HTML