### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -326,6 +326,37 @@
       "platforms": [
         "win-x64"
       ]
+    },
+    {
+      "id": "mmx-cli",
+      "name": "MiniMax CLI",
+      "description": "Generate text, images, video, speech, and music via MiniMax AI platform — MiniMax-M2.7 LLM, image-01, Hailuo-2.3 video, speech-2.8-hd TTS, and music-2.6.",
+      "version": "1.0.0",
+      "category": "integrations",
+      "url": "https://github.com/MiniMax-AI/cli",
+      "repo_url": "https://github.com/MiniMax-AI/cli",
+      "tags": [
+        "llm",
+        "image-generation",
+        "video-generation",
+        "tts",
+        "music-generation",
+        "minimax"
+      ],
+      "platforms": [
+        "linux-x64",
+        "linux-arm64",
+        "darwin-arm64",
+        "darwin-x64",
+        "win-x64"
+      ],
+      "capabilities": [
+        "text_generation",
+        "image_generation",
+        "video_generation",
+        "speech_synthesis",
+        "music_generation"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` to `skills.json` so the mmx-cli skill is discoverable out of the box
- References the external repo at https://github.com/MiniMax-AI/cli (same pattern as existing `camera-claw` entry)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**31 lines added, 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard.

## Test plan

- `skills.json` is valid JSON (verified with `python3 -c "import json; json.load(open('skills.json'))"`)
- New entry follows the same external-repo pattern as `camera-claw`
- No existing skills are modified